### PR TITLE
code for context card

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# packaged front end code
+wwwroot/dist/*

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ As an example use case, you may want to embed a Teams chat into your Support Des
 1. Create a new chat
 1. Show latest chat messages (the message count fetched is configurable)
 1. Send a message to the chat
-1. Send and render adaptive card in chat message
 1. Add participants
 1. Receive chats in near real time
 1. Receive participant changes in near real time
@@ -35,6 +34,37 @@ teamsEmbeddedChat.renderEmbed(
     }
 );
 </script>
+```
+
+### Configurable Options
+
+Chat conversations can be initiated by selecting a number of configuration options.
+
+| **Field**      | **Mandatory** | **Default Value**     | **Description** |
+| :---        |    :----:   |                  :--- |                 :--- |
+| Notification Source      | Yes       | Microsoft Graph  | Notification engine for delivering real time notifications with option to select either Microsoft Graph or ACS w/ Online Meeting. |
+| Entity ID   | Yes        | ' '     | Unique identifier that is used to identify a specific chat conversation. |
+| Chat Topic   | No        | Entity ID      | Subject or topic of a specific chat conversation.|
+| Chat Context Card JSON   | No        | ' '     | Information that describes a particular chat conversation in the form of an adaptive card JSON payload. |
+| Participants   | No        | ' '      | Participants Email address used to identify and reference a specific participant in the context of a chat conversation. |
+| Disable add participants   | No        | False    | Option to disable further addition of participants to a chat conversation from embedded chat UI, once chat has been initiated. |
+
+
+> **Note**   
+> The current version of the embedded chat does not support interactive elements such as actions in adaptive cards.
+> Feature to send Adaptive card in a ***chat message*** is currently not supported(Except chat context card). The adaptive card will, however, be rendered if sent via Teams.
+
+</em>
+
+#### Sample Configuration
+
+```text
+entityId: CR-786543
+topicName: Product development and testing requests- ES
+contextCard: { "$schema": "http://adaptivecards.io/schemas/adaptive-card.json", "type": "AdaptiveCard", "version": "1.5", "body": [ { "type": "TextBlock", "text": "Hi, can we chat about this Change Request?", "size": "Large", "weight": "Bolder" }, { "type": "TextBlock", "text": "This is a sample Chat Context Adaptive Card sent from Embedded Chat.", "wrap": true }, { "type": "Image", "url": "https://www.logodesignlove.com/wp-content/uploads/2012/08/microsoft-logo-02.jpeg", "size": "Medium" } ] }
+participants: alex@mngenvmcap773902.onmicrosoft.com
+disableAddParticipants: true
+
 ```
 
 ## Resources Needed

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ As an example use case, you may want to embed a Teams chat into your Support Des
 1. Create a new chat
 1. Show latest chat messages (the message count fetched is configurable)
 1. Send a message to the chat
+1. Send and render adaptive card in chat message
 1. Add participants
 1. Receive chats in near real time
 1. Receive participant changes in near real time

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
       "build": "webpack --config=webpack.config.js --env=mode=production"
     },
     "dependencies": {
-        "@azure/communication-signaling": "^1.0.0-beta.15"
+        "@azure/communication-signaling": "^1.0.0-beta.15",
+        "adaptivecards": "^2.10.0"
       },
     "devDependencies": {
       "@types/node": "17.0.23",

--- a/wwwroot/EmbeddedChat.css
+++ b/wwwroot/EmbeddedChat.css
@@ -18,40 +18,10 @@
   }
 
    /* Start Adaptive Card Styles */
-  .ac-container {
+   .ac-container {
     background-color: #ffffff;
-    border: 2px solid #2e0885;
-    border-radius: 4px;
-  }
-  
-  .ac-container .ac-header {
-    border-bottom: 1px solid #d9d9d9;
-  }
-  
-  .ac-container .ac-header .ac-title {
-    color: #333333;
-  }
-  
-  .ac-container .ac-header .ac-subtitle {
-    color: #f03c3c;
-  }
-  
-  .ac-container .ac-body .ac-text {
-    color: #333333;
-  }
-  
-  .ac-container .ac-body .ac-factset {
-    color: #333333;
-  }
-  
-  .ac-container .ac-actions .ac-action {
-    background-color: #f2f2f2;
-    color: #333333;
-    border: 1px solid #d9d9d9;
-  }
-  
-  .ac-container .ac-actions .ac-action:hover {
-    background-color: #e6e6e6;
+    border: 2px solid #f0f0f0;
+    border-radius: 1px;
   }
 
   .teams-embed-chat-message-content .ac-container div {

--- a/wwwroot/EmbeddedChat.css
+++ b/wwwroot/EmbeddedChat.css
@@ -53,6 +53,10 @@
   .ac-container .ac-actions .ac-action:hover {
     background-color: #e6e6e6;
   }
+
+  .teams-embed-chat-message-content .ac-container div {
+    white-space: normal !important;
+  }
   
   /* Start Teams Embed Styles */
   .teams-embed-container {

--- a/wwwroot/EmbeddedChat.css
+++ b/wwwroot/EmbeddedChat.css
@@ -18,8 +18,6 @@
   }
 
    /* Start Adaptive Card Styles */
-
-   
   .ac-container {
     background-color: #ffffff;
     border: 2px solid #2e0885;

--- a/wwwroot/EmbeddedChat.css
+++ b/wwwroot/EmbeddedChat.css
@@ -16,6 +16,45 @@
     margin-left: -200px;
     top: 20px;
   }
+
+   /* Start Adaptive Card Styles */
+
+   
+  .ac-container {
+    background-color: #ffffff;
+    border: 2px solid #2e0885;
+    border-radius: 4px;
+  }
+  
+  .ac-container .ac-header {
+    border-bottom: 1px solid #d9d9d9;
+  }
+  
+  .ac-container .ac-header .ac-title {
+    color: #333333;
+  }
+  
+  .ac-container .ac-header .ac-subtitle {
+    color: #f03c3c;
+  }
+  
+  .ac-container .ac-body .ac-text {
+    color: #333333;
+  }
+  
+  .ac-container .ac-body .ac-factset {
+    color: #333333;
+  }
+  
+  .ac-container .ac-actions .ac-action {
+    background-color: #f2f2f2;
+    color: #333333;
+    border: 1px solid #d9d9d9;
+  }
+  
+  .ac-container .ac-actions .ac-action:hover {
+    background-color: #e6e6e6;
+  }
   
   /* Start Teams Embed Styles */
   .teams-embed-container {

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -158,6 +158,8 @@
                     }
                     if ($("#txtChatTopic").val() && $("#txtChatTopic").val().length > 0)
                         text += `        topicName: "${$("#txtChatTopic").val()}",\n`;
+                    if ($("#txtContextCard").val() && $("#txtContextCard").val().length > 0)
+                        text += `        contextCard: "${$("#txtContextCard").val()}",\n`;
                     if ($("#txtParticipants").val() && $("#txtParticipants").val().length > 0) {
                         var p = $("#txtParticipants").val().split(";");
                         var pFlat = p.join("\",\"");

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -11,8 +11,8 @@
             <div id="header" style="width: 1080px; height: 60px; position: absolute; left: 50%; margin-left: -540px; top: 20px; color: #fff">
                 <h1>Teams Embedded Chat Sample</h1>
             </div>
-            <div id="embed" style="width: 400px; height: 500px; position: absolute; left: 50%; margin-left: -540px; top: 80px; border: 1px solid #333; background: white;"></div>
-            <div id="ctrls" style="width: 260px; height: 500px; position: absolute; left: 50%; margin-left: -120px; top: 80px; border: 1px solid #333; background: white; padding: 15px;">
+            <div id="embed" style="width: 400px; height: 600px; position: absolute; left: 50%; margin-left: -540px; top: 80px; border: 1px solid #333; background: white;"></div>
+            <div id="ctrls" style="width: 260px; height: 600px; position: absolute; left: 50%; margin-left: -120px; top: 80px; border: 1px solid #333; background: white; padding: 15px;">
                 <div class="form-group">
                     <label for="txtEntityId">Notification Source</label>
                     <div class="form-check">
@@ -37,6 +37,10 @@
                     <input type="text" class="form-control" id="txtChatTopic">
                 </div>
                 <div class="form-group">
+                    <label for="txtContextCard">Chat Context Card JSON</label>
+                    <input type="text" class="form-control" id="txtContextCard">
+                </div>
+                <div class="form-group">
                     <label for="txtParticipants">Participants</label>
                     <input type="text" class="form-control" id="txtParticipants" placeholder="ex: foo@bar.com;test@user.com">
                 </div>
@@ -50,7 +54,7 @@
                 <button id="refresh" class="btn btn-primary btn-block" disabled>Start Chat</button>
                 <button id="reset" class="btn btn-secondary btn-block">Reload Form</button>
             </div>
-            <div id="editor" style="width: 400px; height: 500px; position: absolute; left: 50%; margin-left: 160px; top: 80px; border: 1px solid #333; background: #282c34;">
+            <div id="editor" style="width: 400px; height: 600px; position: absolute; left: 50%; margin-left: 160px; top: 80px; border: 1px solid #333; background: #282c34;">
                 <pre>
 <code class="language-html"></code>
                 </pre>
@@ -187,6 +191,9 @@
                     } else {
                         // if not topic name is entered give chat name of entityId
                         config.topicName = $("#txtEntityId").val();
+                    }
+                    if ($("#txtContextCard").val().length > 0) {
+                        config.contextCard = $("#txtContextCard").val();
                     }
                     if ($("#txtParticipants").val().length > 0) {
                         var participants = $("#txtParticipants").val().split(";");

--- a/wwwroot/src/Components/App.ts
+++ b/wwwroot/src/Components/App.ts
@@ -93,7 +93,7 @@ export class App {
 
                 // update the mapping in the database with all the new thread info
                 await mappingUtil.updateMapping(mapping, appAuthResult.accessToken);
-                
+
                 // remove the add participant dialog
                 element.removeChild(dialog);
                 
@@ -164,7 +164,7 @@ export class App {
         }
     }
 
-    private initializeChat = async (notificationClient: INotificationClient, element: Element, mapping: Mapping, participants: Person[], isNew: boolean, contextCard:string|undefined) => {
+    private initializeChat = async (notificationClient: INotificationClient, element: Element, mapping: Mapping, participants: Person[], isNew: boolean, contextCard: string|undefined) => {
         if (!mapping.threadInfo?.threadId) {
             console.error("There was an error in adding the initializeChat");
             return;

--- a/wwwroot/src/Components/ChatContainer.ts
+++ b/wwwroot/src/Components/ChatContainer.ts
@@ -14,6 +14,7 @@ import { INotificationClient } from "../NotificationClients/INotificationClient"
 import { Waiting } from "./Waiting";
 import { StatusIcon } from "./StatusIcon";
 import { AlertHandler } from "../Models/AlertAction";
+import * as AdaptiveCards from "adaptivecards";
 
 const template = document.createElement("template");
 template.innerHTML = `
@@ -37,6 +38,8 @@ template.innerHTML = `
         <div class="teams-embed-chat">
             <div class="teams-embed-chat-container">
                 <ul class="teams-embed-chat-items">
+                    <div class ="adaptive-card">
+                    </div>
                 </ul>
             </div>
         </div>
@@ -82,8 +85,9 @@ export class ChatContainer extends HTMLElement {
     private mapping: Mapping;
     private notificationClient:INotificationClient;
     private alertHandler: AlertHandler;
+    private cardPayLoad: string|null;
 
-    constructor(notificationClient: INotificationClient, messages: ChatMessage[], mapping: Mapping, participants: Person[], authUtil: AuthUtil, photoUtil: PhotoUtil, waiting:Waiting, alertHandler: AlertHandler) {
+    constructor(notificationClient: INotificationClient, messages: ChatMessage[], mapping: Mapping, participants: Person[], authUtil: AuthUtil, photoUtil: PhotoUtil, waiting:Waiting, alertHandler: AlertHandler, cardPayLoad: string|undefined) {
         super();
         this.waiting = waiting;
         this.chatTitle = mapping.threadInfo?.topicName ?? "";
@@ -95,6 +99,8 @@ export class ChatContainer extends HTMLElement {
         this.mentionInput = "";
         this.participants = participants;
         this.mapping = mapping;
+        this.cardPayLoad =
+          cardPayLoad === undefined ? null : JSON.stringify(cardPayLoad);
         this.notificationClient = notificationClient;
         this.alertHandler = alertHandler;
         this.render();
@@ -378,7 +384,8 @@ export class ChatContainer extends HTMLElement {
         const res = await GraphUtil.sendChatMessage(
             authInfo.accessToken,
             this.mapping.threadInfo.threadId,
-            messageHtml
+            messageHtml,
+            false
         );
 
         if (!res) {
@@ -422,6 +429,18 @@ export class ChatContainer extends HTMLElement {
         // get the template
         const dom = <HTMLElement>template.content.cloneNode(true);
 
+        //Create an adaptivecard instance
+        const adaptiveCard = new AdaptiveCards.AdaptiveCard();
+        var renderedCard;
+
+        if (this.cardPayLoad != null) {
+          const cardJson = JSON.parse(this.cardPayLoad);
+
+          //Parse the card Payload
+          adaptiveCard.parse(cardJson);
+          //Render the card to an HTML Element
+          renderedCard = adaptiveCard.render();
+        }
         // set chat title
         (<HTMLElement>dom.querySelector(".teams-embed-header-text")).innerHTML = `<h2>${this.chatTitle}</h2>`;
 
@@ -444,6 +463,27 @@ export class ChatContainer extends HTMLElement {
 
         // add the add participant dialog
         (<HTMLElement>dom.querySelector(".teams-embed-container")).appendChild(this.dialog);
+        
+        const newerChatItem = document.getElementsByClassName(
+          "teams-embed-chat-items"
+        );
+        
+        // render adaptivecard as first item in chat items
+        if (this.cardPayLoad != null && renderedCard !== undefined && newerChatItem != null) {
+            const container = <HTMLElement>dom.querySelector(".adaptive-card");
+            if (container != null) {
+              container.innerHTML = renderedCard.outerHTML;
+            }
+            if (newerChatItem.length == 0) {
+              (<HTMLElement>(
+                dom.querySelector(".teams-embed-chat-items")
+              )).append(container);
+            } else {
+              (<HTMLElement>(
+                dom.querySelector(".teams-embed-chat-items")
+              )).insertBefore(newerChatItem[1], container);
+            }
+        }
 
         // wire even to toggle participant list
         (<HTMLElement>dom.querySelector(".teams-embed-header-participants-button")).addEventListener("click", () => {

--- a/wwwroot/src/Components/ChatContainer.ts
+++ b/wwwroot/src/Components/ChatContainer.ts
@@ -14,7 +14,6 @@ import { INotificationClient } from "../NotificationClients/INotificationClient"
 import { Waiting } from "./Waiting";
 import { StatusIcon } from "./StatusIcon";
 import { AlertHandler } from "../Models/AlertAction";
-import * as AdaptiveCards from "adaptivecards";
 
 const template = document.createElement("template");
 template.innerHTML = `
@@ -38,8 +37,6 @@ template.innerHTML = `
         <div class="teams-embed-chat">
             <div class="teams-embed-chat-container">
                 <ul class="teams-embed-chat-items">
-                    <div class ="adaptive-card">
-                    </div>
                 </ul>
             </div>
         </div>
@@ -85,9 +82,8 @@ export class ChatContainer extends HTMLElement {
     private mapping: Mapping;
     private notificationClient:INotificationClient;
     private alertHandler: AlertHandler;
-    private cardPayLoad: string|null;
 
-    constructor(notificationClient: INotificationClient, messages: ChatMessage[], mapping: Mapping, participants: Person[], authUtil: AuthUtil, photoUtil: PhotoUtil, waiting:Waiting, alertHandler: AlertHandler, cardPayLoad: string|undefined) {
+    constructor(notificationClient: INotificationClient, messages: ChatMessage[], mapping: Mapping, participants: Person[], authUtil: AuthUtil, photoUtil: PhotoUtil, waiting:Waiting, alertHandler: AlertHandler) {
         super();
         this.waiting = waiting;
         this.chatTitle = mapping.threadInfo?.topicName ?? "";
@@ -99,8 +95,6 @@ export class ChatContainer extends HTMLElement {
         this.mentionInput = "";
         this.participants = participants;
         this.mapping = mapping;
-        this.cardPayLoad =
-          cardPayLoad === undefined ? null : JSON.stringify(cardPayLoad);
         this.notificationClient = notificationClient;
         this.alertHandler = alertHandler;
         this.render();
@@ -429,18 +423,6 @@ export class ChatContainer extends HTMLElement {
         // get the template
         const dom = <HTMLElement>template.content.cloneNode(true);
 
-        //Create an adaptivecard instance
-        const adaptiveCard = new AdaptiveCards.AdaptiveCard();
-        var renderedCard;
-
-        if (this.cardPayLoad != null) {
-          const cardJson = JSON.parse(this.cardPayLoad);
-
-          //Parse the card Payload
-          adaptiveCard.parse(cardJson);
-          //Render the card to an HTML Element
-          renderedCard = adaptiveCard.render();
-        }
         // set chat title
         (<HTMLElement>dom.querySelector(".teams-embed-header-text")).innerHTML = `<h2>${this.chatTitle}</h2>`;
 
@@ -463,27 +445,6 @@ export class ChatContainer extends HTMLElement {
 
         // add the add participant dialog
         (<HTMLElement>dom.querySelector(".teams-embed-container")).appendChild(this.dialog);
-        
-        const newerChatItem = document.getElementsByClassName(
-          "teams-embed-chat-items"
-        );
-        
-        // render adaptivecard as first item in chat items
-        if (this.cardPayLoad != null && renderedCard !== undefined && newerChatItem != null) {
-            const container = <HTMLElement>dom.querySelector(".adaptive-card");
-            if (container != null) {
-              container.innerHTML = renderedCard.outerHTML;
-            }
-            if (newerChatItem.length == 0) {
-              (<HTMLElement>(
-                dom.querySelector(".teams-embed-chat-items")
-              )).append(container);
-            } else {
-              (<HTMLElement>(
-                dom.querySelector(".teams-embed-chat-items")
-              )).insertBefore(newerChatItem[1], container);
-            }
-        }
 
         // wire even to toggle participant list
         (<HTMLElement>dom.querySelector(".teams-embed-header-participants-button")).addEventListener("click", () => {

--- a/wwwroot/src/Components/ChatItem.ts
+++ b/wwwroot/src/Components/ChatItem.ts
@@ -58,10 +58,11 @@ export class ChatItem extends HTMLElement {
                     // set the innerHtml of the message content to the HTML of the adaptive card
                     contentDom.innerHTML = renderedCard.outerHTML;
                 } else {
+                    // message has an attachment, but is not an adaptive card
                     (<HTMLElement>dom.querySelector(".teams-embed-chat-message-content")).innerHTML = "<p style='font-style: italic'>This message is unsupported.</p>";
                 }
             } else {
-                // set the message texton the element
+                // if it is a message, set the message text on the element
                 (<HTMLElement>dom.querySelector(".teams-embed-chat-message-content")).innerHTML = message.message;
             }
 

--- a/wwwroot/src/Components/ChatItem.ts
+++ b/wwwroot/src/Components/ChatItem.ts
@@ -59,7 +59,7 @@ export class ChatItem extends HTMLElement {
                     contentDom.innerHTML = renderedCard.outerHTML;
                 } else {
                     // message has an attachment, but is not an adaptive card
-                    (<HTMLElement>dom.querySelector(".teams-embed-chat-message-content")).innerHTML = "<p style='font-style: italic'>This message is unsupported.</p>";
+                    (<HTMLElement>dom.querySelector(".teams-embed-chat-message-content")).innerHTML = "<p style='font-style: italic'>This message type is unsupported.</p>";
                 }
             } else {
                 // if it is a message, set the message text on the element

--- a/wwwroot/src/Components/ChatItem.ts
+++ b/wwwroot/src/Components/ChatItem.ts
@@ -41,7 +41,7 @@ export class ChatItem extends HTMLElement {
             // update text only
             (<HTMLElement>dom.querySelector(".teams-embed-chat-message-content")).innerHTML = "<p style='font-style: italic'>This message has been deleted</p>";
         } else {
-            if (message.attachment != null) { //&& message.attachment?.type == "AdaptiveCard") {
+            if (message.attachment != null) {
                 if (message.attachment?.type == "AdaptiveCard") {
                 // create adaptive card Instance
                 const adaptiveCard = new AdaptiveCards.AdaptiveCard();

--- a/wwwroot/src/Components/ChatItem.ts
+++ b/wwwroot/src/Components/ChatItem.ts
@@ -24,9 +24,6 @@ template.innerHTML = `
         </div>
     </li>`;
 
-const adaptiveCardTemplate = document.createElement("template");
-adaptiveCardTemplate.innerHTML = `<div class="adaptive-card"></div>`
-
 export class ChatItem extends HTMLElement {
     constructor(message: ChatMessage, isMe: boolean) {
         super();

--- a/wwwroot/src/Components/ChatItem.ts
+++ b/wwwroot/src/Components/ChatItem.ts
@@ -18,7 +18,6 @@ template.innerHTML = `
                     <span class="teams-embed-chat-message-timestamp"></span>
                 </div>
                 <div class="teams-embed-chat-message-content"></div>
-                <div class="adaptive-card"></div>
             </div>
             <div class="teams-embed-chat-message-send-status">
             </div>
@@ -56,16 +55,11 @@ export class ChatItem extends HTMLElement {
                 // rendered the card to an HTML Element
                 let renderedCard = adaptiveCard.render();
 
-                const adaptiveCardDom = <HTMLElement>adaptiveCardTemplate.content.cloneNode(true);
-                if (renderedCard != undefined)
-                    adaptiveCardDom.innerHTML = renderedCard.outerHTML;
-
-                // let contentDom = (<HTMLElement>dom.querySelector(".teams-embed-chat-message-content"));
-                // contentDom.appendChild(adaptiveCardDom);
-
-                const container = <HTMLElement>dom.querySelector(".adaptive-card");
-                if (container != null && renderedCard != undefined)
-                    container.innerHTML = renderedCard.outerHTML;
+                // get the message content element
+                let contentDom = (<HTMLElement>dom.querySelector(".teams-embed-chat-message-content"));
+                if (contentDom != null && renderedCard != undefined)
+                    // set the innerHtml of the message content to the HTML of the adaptive card
+                    contentDom.innerHTML = renderedCard.outerHTML;
                 } else {
                     (<HTMLElement>dom.querySelector(".teams-embed-chat-message-content")).innerHTML = "<p style='font-style: italic'>This message is unsupported.</p>";
                 }

--- a/wwwroot/src/Components/ChatItem.ts
+++ b/wwwroot/src/Components/ChatItem.ts
@@ -1,5 +1,6 @@
 import { ChatMessage } from "../Models/ChatMessage"
 import { StatusIcon } from "./StatusIcon";
+import * as AdaptiveCards from "adaptivecards";
 
 const one_day_in_ms = 1000 * 60 * 60 * 24;
 const template = document.createElement("template");
@@ -17,6 +18,8 @@ template.innerHTML = `
                     <span class="teams-embed-chat-message-timestamp"></span>
                 </div>
                 <div class="teams-embed-chat-message-content"></div>
+                <div class ="adaptive-card">
+                </div>
             </div>
             <div class="teams-embed-chat-message-send-status">
             </div>
@@ -34,6 +37,24 @@ export class ChatItem extends HTMLElement {
         (<HTMLElement>dom.querySelector(".teams-embed-avatar")).classList.add(message.sender.id);
         (<HTMLImageElement>dom.querySelector(".teams-embed-avatar-image")).src = message.sender.photo;
         (<HTMLElement>dom.querySelector(".teams-embed-chat-message-author")).innerText = message.sender.displayName;
+
+        if (message.attachment != null)
+        {
+            //Create adaptive card Instance
+            const adaptiveCard = new AdaptiveCards.AdaptiveCard();
+            var renderedCard;
+            
+            //Parse the Card payload
+            adaptiveCard.parse(message.attachment);
+
+            //Rendered the card to an HTML Element
+            renderedCard = adaptiveCard.render();
+            
+            const container = <HTMLElement>dom.querySelector(".adaptive-card");
+            if (container != null && renderedCard != undefined)
+               container.innerHTML = renderedCard.outerHTML;
+            
+        }
 
         if (message.deletedOn) {
             // if message has been deleted

--- a/wwwroot/src/Models/ChatMessage.ts
+++ b/wwwroot/src/Models/ChatMessage.ts
@@ -11,4 +11,5 @@ export interface ChatMessage {
     modifiedOn: Date;
     deletedOn?: Date;
     sendFailed?: boolean;
+    attachment?: JSON;
 }

--- a/wwwroot/src/Models/ChatMessage.ts
+++ b/wwwroot/src/Models/ChatMessage.ts
@@ -11,5 +11,5 @@ export interface ChatMessage {
     modifiedOn: Date;
     deletedOn?: Date;
     sendFailed?: boolean;
-    attachment?: JSON;
+    attachment?: any;
 }

--- a/wwwroot/src/Models/EmbeddedChatConfig.ts
+++ b/wwwroot/src/Models/EmbeddedChatConfig.ts
@@ -3,4 +3,5 @@ export type EmbeddedChatConfig = {
     topicName?: string;
     participants?: string[];
     disableAddParticipants?: boolean;
+    contextCard?: string;
 };

--- a/wwwroot/src/Models/Mapping.ts
+++ b/wwwroot/src/Models/Mapping.ts
@@ -3,7 +3,8 @@ import { Person } from "./Person";
 export interface Mapping {
     entityId: string;
     disableAddParticipants: boolean;
-    threadInfo?: ThreadInfo; 
+    threadInfo?: ThreadInfo;
+    contextCard?: string; 
 }
 
 export interface ThreadInfo {

--- a/wwwroot/src/Models/Mapping.ts
+++ b/wwwroot/src/Models/Mapping.ts
@@ -4,7 +4,6 @@ export interface Mapping {
     entityId: string;
     disableAddParticipants: boolean;
     threadInfo?: ThreadInfo;
-    contextCard?: string; 
 }
 
 export interface ThreadInfo {

--- a/wwwroot/src/NotificationClients/AcsMeetingNotificationClient.ts
+++ b/wwwroot/src/NotificationClients/AcsMeetingNotificationClient.ts
@@ -161,7 +161,8 @@ export class AcsMeetingNotificationClient implements INotificationClient {
         type: e.type,
         //version: "",
         createdOn: e.createdOn,
-        modifiedOn: e.createdOn, //TODO
+        modifiedOn: e.createdOn,
+        attachment: e.attachments?.length > 0 ? JSON.parse(e.attachments[0].content) : null
       };
       if (this.chatListener) this.chatListener(msg, Operation.Created);
     });

--- a/wwwroot/src/NotificationClients/GraphNotificationClient.ts
+++ b/wwwroot/src/NotificationClients/GraphNotificationClient.ts
@@ -172,7 +172,9 @@ export class GraphNotificationClient implements INotificationClient {
                         createdOn: new Date(decryptedResourceData.createdDateTime),
                         modifiedOn: new Date(decryptedResourceData.lastModifiedDateTime),
                         editedOn: (decryptedResourceData.lastEditedDateTime) ?
-                            new Date(decryptedResourceData.lastEditedDateTime) : undefined
+                            new Date(decryptedResourceData.lastEditedDateTime) : undefined,
+                        attachment: (decryptedResourceData.attachments) ?.length > 0 ? 
+                            JSON.parse(decryptedResourceData.attachments[0].content) : null
                     }
 
                     // call the chatListener

--- a/wwwroot/src/Utils/AdaptiveCardUtil.ts
+++ b/wwwroot/src/Utils/AdaptiveCardUtil.ts
@@ -1,4 +1,5 @@
-const adaptiveCardMessage = (chatDescription: string) => {
+export class AdaptiveCardMessage {
+  static adaptiveCardMessage = (adaptiveCard: string) => {
   const adaptiveCardTemplate = {
     body: {
       contentType: "html",
@@ -9,12 +10,11 @@ const adaptiveCardMessage = (chatDescription: string) => {
       {
         id: "adaptive34aa4a7fb74e2b300012card",
         contentType: "application/vnd.microsoft.card.adaptive",
-        content: chatDescription,
+        content: adaptiveCard,
       },
     ],
   };
 
   return JSON.stringify(adaptiveCardTemplate);
 };
-
-module.exports = {adaptiveCardMessage};
+}

--- a/wwwroot/src/Utils/AdaptiveCardUtil.ts
+++ b/wwwroot/src/Utils/AdaptiveCardUtil.ts
@@ -1,0 +1,20 @@
+const adaptiveCardMessage = (chatDescription: string) => {
+  const adaptiveCardTemplate = {
+    body: {
+      contentType: "html",
+      content:
+        '<attachment id=\"adaptive34aa4a7fb74e2b300012card\"></attachment>',
+    },
+    attachments: [
+      {
+        id: "adaptive34aa4a7fb74e2b300012card",
+        contentType: "application/vnd.microsoft.card.adaptive",
+        content: chatDescription,
+      },
+    ],
+  };
+
+  return JSON.stringify(adaptiveCardTemplate);
+};
+
+module.exports = {adaptiveCardMessage};

--- a/wwwroot/src/Utils/GraphUtil.ts
+++ b/wwwroot/src/Utils/GraphUtil.ts
@@ -154,9 +154,9 @@ export class GraphUtil {
     public static sendChatMessage = async (token: string, chatId: string, message: string, isAdaptiveCard: boolean) => {
         var payload;
         if(!isAdaptiveCard)
-            payload= FormatterUtil.formatMessageBody(message);
+            payload = FormatterUtil.formatMessageBody(message);
         else
-            payload= JSON.parse(message);
+            payload = JSON.parse(message);
         try {
             const resp = await fetch(`https://graph.microsoft.com/v1.0/chats/${chatId}/messages`, {
                 method: "POST",

--- a/wwwroot/src/Utils/GraphUtil.ts
+++ b/wwwroot/src/Utils/GraphUtil.ts
@@ -151,9 +151,9 @@ export class GraphUtil {
     };
 
     // sends a chat message
-    public static sendChatMessage = async (token: string, chatId: string, message: string, isContextCard: boolean) => {
+    public static sendChatMessage = async (token: string, chatId: string, message: string, isAdaptiveCard: boolean) => {
         var payload;
-        if(!isContextCard)
+        if(!isAdaptiveCard)
             payload= FormatterUtil.formatMessageBody(message);
         else
             payload= JSON.parse(message);

--- a/wwwroot/src/Utils/GraphUtil.ts
+++ b/wwwroot/src/Utils/GraphUtil.ts
@@ -152,7 +152,7 @@ export class GraphUtil {
 
     // sends a chat message
     public static sendChatMessage = async (token: string, chatId: string, message: string, isAdaptiveCard: boolean) => {
-        var payload;
+        let payload;
         if(!isAdaptiveCard)
             payload = FormatterUtil.formatMessageBody(message);
         else

--- a/wwwroot/src/Utils/GraphUtil.ts
+++ b/wwwroot/src/Utils/GraphUtil.ts
@@ -151,9 +151,12 @@ export class GraphUtil {
     };
 
     // sends a chat message
-    public static sendChatMessage = async (token: string, chatId: string, message: string) => {
-        const payload= FormatterUtil.formatMessageBody(message);
-        
+    public static sendChatMessage = async (token: string, chatId: string, message: string, isContextCard: boolean) => {
+        var payload;
+        if(!isContextCard)
+            payload= FormatterUtil.formatMessageBody(message);
+        else
+            payload= JSON.parse(message);
         try {
             const resp = await fetch(`https://graph.microsoft.com/v1.0/chats/${chatId}/messages`, {
                 method: "POST",


### PR DESCRIPTION
Added code to pass optional chat context in form of adaptive card JSON payload. 

Sample payload 
{
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "type": "AdaptiveCard",
    "version": "1.5",
    "body": [
        {
            "type": "TextBlock",
            "text": "Hi, can we chat about this?",
            "size": "Large",
            "weight": "Bolder"
        },
        {
            "type": "TextBlock",
            "text": "This is a sample Chat Context Adaptive Card sent from Embedded Chat.",
            "wrap": true
        },
        {
            "type": "Image",
            "url": "https://www.logodesignlove.com/wp-content/uploads/2012/08/microsoft-logo-02.jpeg",
            "size": "Medium"
        }
    ]
}
As of now, actions in adaptive card are not supported in this feature.