### PR TITLE
Add user deploying solution as a Key Vault Admin

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
 		"dockerfile": "Dockerfile",
 		// Update 'VARIANT' to pick an Ubuntu version: focal, bionic
 		"args": {
-			"VARIANT": "6.0"
+			"VARIANT": "7.0"
 		}
 	},
 	"settings": {

--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,10 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Prevent package-lock.json from being checked in
+package-lock.json
+
+## Users settings
+.env.[Dd]evelopment
+.env.[Pp]roduction

--- a/Scripts/CreateAppRegistrations.ps1
+++ b/Scripts/CreateAppRegistrations.ps1
@@ -128,6 +128,10 @@ try {
         }
     }
     $appSecret = Add-MgApplicationPassword -ApplicationId $embeddedChatApplication.Id @secretParams
+
+    # Get current User Oid
+    $context = Get-MgContext
+    $user = Get-MgUser -Filter "UserPrincipalName eq '$($context.Account)'"
   
     $paramsOutput = @{
         '$schema'        = 'https=//schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#'
@@ -136,10 +140,13 @@ try {
             'appName'         = @{
                 'value' = $ApplicationName
             }
-            'ClientId'     = @{
+            'userId'= @{
+                'value' = $user.Id
+            }
+            'clientId'     = @{
                 'value' = $embeddedChatApplication.AppId
             }
-            'ClientSecret' = @{
+            'clientSecret' = @{
                 'value' = $appSecret.SecretText
             }
         }

--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -1,4 +1,5 @@
 param appName string
+param userId string
 param clientId string
 @secure()
 param clientSecret string
@@ -14,6 +15,7 @@ module uai 'uai.bicep' = {
   name: 'dp${appName}-uai'
   params: {
     name: appName
+    userId: userId
   }
 }
 

--- a/bicep/main.parameters.template.json
+++ b/bicep/main.parameters.template.json
@@ -2,13 +2,16 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-      "AppName": {
+      "appName": {
         "value": ""
       },
-      "ClientId": {
+      "userId": {
         "value": ""
       },
-      "ClientSecret": {
+      "clientId": {
+        "value": ""
+      },
+      "clientSecret": {
         "value": ""
       }
     }

--- a/bicep/uai.bicep
+++ b/bicep/uai.bicep
@@ -1,6 +1,6 @@
 param name string
-// @description('Specifies the object ID of a user, service principal or security group in the Azure Active Directory tenant for the vault. The object ID must be unique for the list of access policies. Get it by using Get-AzADUser or Get-AzADServicePrincipal cmdlets.')
-// param userId string
+@description('Specifies the object ID of a user, service principal or security group in the Azure Active Directory tenant for the vault. The object ID must be unique for the list of access policies. Get it by using Get-AzADUser or Get-AzADServicePrincipal cmdlets.')
+param userId string
 
 // create user assigned managed identity
 resource uai 'Microsoft.ManagedIdentity/userAssignedIdentities@2022-01-31-preview' = {
@@ -19,12 +19,12 @@ resource uaiSecretsUserRoleAssignment 'Microsoft.Authorization/roleAssignments@2
   }
 }
 
-// var keyVaultAdminRoleId = '00482a5a-887f-4fb3-b363-3b7fe8e74483'
-// // grant key vault admin to current user
-// resource userKeyVaultRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-//   name: guid(resourceGroup().id, keyVaultAdminRoleId, userId)
-//   properties: {
-//     principalId: userId
-//     roleDefinitionId: '${subscription().id}/providers/Microsoft.Authorization/roleDefinitions/${keyVaultAdminRoleId}'
-//   }
-// }
+var keyVaultAdminRoleId = '00482a5a-887f-4fb3-b363-3b7fe8e74483'
+// grant key vault admin to current user
+resource userKeyVaultRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, keyVaultAdminRoleId, userId)
+  properties: {
+    principalId: userId
+    roleDefinitionId: '${subscription().id}/providers/Microsoft.Authorization/roleDefinitions/${keyVaultAdminRoleId}'
+  }
+}


### PR DESCRIPTION
The user deploying the solution needs to have rights to add the secrets to Key Vault. In case the user does not already have rights, this will add the key vault administrator role for the user at the resource group scope. Also, updated the dev container to use dotnet 7.0 to match the version the project expects.