### PR TITLE
Updated for decrypted content sent with new messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -358,3 +358,9 @@ package-lock.json
 
 # packaged front end code
 wwwroot/dist/*
+
+# azurite
+__azurite*.json
+
+# generated files
+main.parameters.json

--- a/wwwroot/src/NotificationClients/GraphNotificationClient.ts
+++ b/wwwroot/src/NotificationClients/GraphNotificationClient.ts
@@ -118,17 +118,22 @@ export class GraphNotificationClient implements INotificationClient {
         });
 
         // message received
-        this.connection.on(this.ReturnMethods.NewMessage, async (notification) => {
+        this.connection.on(this.ReturnMethods.NewMessage, async (notification, decryptedContent) => {
 
-            // decrypt the content
-            const response = await fetch(ConfigUtil.GnbEndpoint + "/api/GetChatMessageFromNotification", {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${gnbToken.accessToken}`
-                },
-                body: JSON.stringify(notification.encryptedContent)
-            });
-            var decryptedResourceData:any = await response.json();
+            // make descryption backwards compatible
+            var decryptedResourceData:any = decryptedContent;
+
+            if (!decryptedResourceData) {
+                // decrypt the content
+                const response = await fetch(ConfigUtil.GnbEndpoint + "/api/GetChatMessageFromNotification", {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${gnbToken.accessToken}`
+                    },
+                    body: JSON.stringify(notification.encryptedContent)
+                });
+                decryptedResourceData = await response.json();
+            }
 
             // get the operation type
             const op:Operation = (notification.changeType == "created") ? Operation.Created 

--- a/wwwroot/src/NotificationClients/GraphNotificationClient.ts
+++ b/wwwroot/src/NotificationClients/GraphNotificationClient.ts
@@ -121,7 +121,19 @@ export class GraphNotificationClient implements INotificationClient {
         this.connection.on(this.ReturnMethods.NewMessage, async (notification, decryptedContent) => {
 
             // make descryption backwards compatible
-            var decryptedResourceData:any = decryptedContent;
+            var decryptedResourceData:any = null;
+            if(decryptedContent.length > 0) {
+                try {
+                    decryptedResourceData = JSON.parse(decryptedContent);
+                } catch (error) {
+                    if (error instanceof SyntaxError) {
+                      console.error(`Failed to parse decrypted content as JSON: ${error.message}`);
+                    } else {
+                      console.error(`Unexpected error parsing decrypted content as JSON: : ${error}`);
+                    }
+                    return;
+                  }
+            }
 
             if (!decryptedResourceData) {
                 // decrypt the content


### PR DESCRIPTION
Updated the GraphNotificationClient to accept the decrypted content when new messages are sent, but left it backwards compatible for requesting decrypted content